### PR TITLE
Build and search trie

### DIFF
--- a/src/hangul.rs
+++ b/src/hangul.rs
@@ -22,6 +22,58 @@ const JONG_SUNG: [char; NUM_FINAL_CONSONANT] = [
     'ㅁ', 'ㅂ', 'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ',
 ];
 
+/// 품사(POS; Part of Speech) 태그 정의
+/// "모두의 말뭉치"에서 정의한 품사 태그를 그대로 사용.
+pub enum PosTag {
+    NNG, //일반명사
+    NNP, //고유명사
+    NNB, //의존명사
+    NP,  //대명사
+    NR,  //수사
+    VV,  //동사
+    VA,  //형용사
+    VX,  //보조용언
+    VCP, //긍정지정사
+    VCN, //부정지정사
+    MMA, //성상 관형사
+    MMD, //지시 관형사
+    MMN, //수 관형사
+    MAG, //일반부사
+    MAJ, //접속부사
+    IC,  //감탄사
+    JKS, //주격조사
+    JKC, //보격조사
+    JKG, //관형격조사
+    JKO, //목적격조사
+    JKB, //부사격조사
+    JKV, //호격조사
+    JKQ, //인용격조사
+    JX,  //보조사
+    JC,  //접속조사
+    EP,  //선어말어미
+    EF,  //종결어미
+    EC,  //연결어미
+    ETN, //명사형전성어미
+    ETM, //관형형전성어미
+    XPN, //체언접두사
+    XSN, //명사파생접미사
+    XSV, //동사파생접미사
+    XSA, //형용사파생접미사
+    XR,  //어근
+    SF,  //마침표, 물음표, 느낌표
+    SP,  //쉼표, 가운뎃점, 콜론, 빗금
+    SS,  //따옴표, 괄호표, 줄표
+    SE,  //줄임표
+    SO,  //붙임표(물결)
+    SW,  //기타 기호
+    SL,  //외국어
+    SH,  //한자
+    SN,  //숫자
+    NA,  //분석불능범주
+    NF,  //명사추정범주
+    NV,  //용언추정범주
+}
+
 /// Def:
 ///     return true if the input syllable is in unicode scope of valid Hangul.
 /// Note:

--- a/src/hangul.rs
+++ b/src/hangul.rs
@@ -1,6 +1,8 @@
 use std::char::from_u32;
 use std::collections::HashMap;
 
+use serde::de::Error;
+
 /// 상수 정의: 유니코드 값 계산을 위해 usize type 사용.
 const HANGUL_START: usize = 44032; // unicode value of '가'
 const HANGUL_END: usize = 55203;
@@ -57,6 +59,9 @@ fn get_char_from_indices(cho_idx: usize, jung_idx: usize, jong_idx: usize) -> ch
 ///     중성 = ((음절의 유니코드 - 오프셋) / 종성개수) % 중성개수
 ///     종성 = (음절의 유니코드 - 오프셋) % 종성개수
 fn get_indices_from_syllable(syllable: char) -> (usize, usize, usize) {
+    if is_hangul(syllable) == false {
+        panic!("given syllable is NOT a Hangul.")
+    }
     let syllable_uni = syllable as usize - HANGUL_START;
 
     let cho_idx = syllable_uni / (NUM_VOWEL_CONSONANT * NUM_FINAL_CONSONANT);
@@ -133,5 +138,21 @@ mod test_korean_strings {
             get_char_from_indices(indices.0, indices.1, indices.2),
             test_char
         );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_indices_from_unicode_goes_panic() {
+        // digit case
+        let mut test_char = '1';
+        get_indices_from_syllable(test_char);
+
+        // english case
+        test_char = 'c';
+        get_indices_from_syllable(test_char);
+
+        // special char case
+        test_char = '#';
+        get_indices_from_syllable(test_char);
     }
 }

--- a/src/hangul.rs
+++ b/src/hangul.rs
@@ -4,14 +4,14 @@ use std::char::from_u32;
 const HANGUL_START: usize = 44032; // unicode value of '가'
 const HANGUL_END: usize = 55203;
 const NUM_INITIAL_CONSONANT: usize = 19; // 초성의 개수
-const NUM_VOWEL_CONSONANT: usize = 21; // 중성의 개수
+const NUM_MID_VOWEL: usize = 21; // 중성의 개수
 const NUM_FINAL_CONSONANT: usize = 28; // 종성의 개수, "없음" 포함
 
 const CHO_SUNG: [char; NUM_INITIAL_CONSONANT] = [
     'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ',
     'ㅌ', 'ㅍ', 'ㅎ',
 ];
-const JUNG_SUNG: [char; NUM_VOWEL_CONSONANT] = [
+const JUNG_SUNG: [char; NUM_MID_VOWEL] = [
     'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ',
     'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ',
 ];
@@ -24,6 +24,8 @@ const JONG_SUNG: [char; NUM_FINAL_CONSONANT] = [
 
 /// 품사(POS; Part of Speech) 태그 정의
 /// "모두의 말뭉치"에서 정의한 품사 태그를 그대로 사용.
+
+#[derive(Debug)]
 pub enum PosTag {
     NNG, //일반명사
     NNP, //고유명사
@@ -75,26 +77,11 @@ pub enum PosTag {
 }
 
 /// Def:
-///     return true if the input syllable is in unicode scope of valid Hangul.
-/// Note:
-///     this function is valid only for the modern Korean chars.
-///
-fn is_hangul(syllable: char) -> bool {
-    let syllable_unicode = syllable as usize;
-
-    if syllable_unicode > HANGUL_END || syllable_unicode < HANGUL_START {
-        return false;
-    } else {
-        return true;
-    }
-}
-
-/// Def:
 ///     get unicode value given cho, jung, jong index.
 /// Note:
 ///     초성의 인덱스는 588(=중성의 개수*종성의 개수) 글자마다 바뀜.
 fn get_char_from_indices(cho_idx: usize, jung_idx: usize, jong_idx: usize) -> char {
-    let res: usize = ((cho_idx * NUM_VOWEL_CONSONANT * NUM_FINAL_CONSONANT)
+    let res: usize = ((cho_idx * NUM_MID_VOWEL * NUM_FINAL_CONSONANT)
         + (jung_idx * NUM_FINAL_CONSONANT)
         + jong_idx)
         + HANGUL_START;
@@ -108,16 +95,41 @@ fn get_char_from_indices(cho_idx: usize, jung_idx: usize, jong_idx: usize) -> ch
 ///     중성 = ((음절의 유니코드 - 오프셋) / 종성개수) % 중성개수
 ///     종성 = (음절의 유니코드 - 오프셋) % 종성개수
 fn get_indices_from_syllable(syllable: char) -> (usize, usize, usize) {
-    if is_hangul(syllable) == false {
-        panic!("given syllable is NOT a Hangul.")
-    }
     let syllable_uni = syllable as usize - HANGUL_START;
 
-    let cho_idx = syllable_uni / (NUM_VOWEL_CONSONANT * NUM_FINAL_CONSONANT);
-    let jung_idx = (syllable_uni / NUM_FINAL_CONSONANT) % NUM_VOWEL_CONSONANT;
+    let cho_idx = syllable_uni / (NUM_MID_VOWEL * NUM_FINAL_CONSONANT);
+    let jung_idx = (syllable_uni / NUM_FINAL_CONSONANT) % NUM_MID_VOWEL;
     let jong_idx = syllable_uni % NUM_FINAL_CONSONANT;
 
     return (cho_idx, jung_idx, jong_idx);
+}
+
+/// Def:
+///     return true if the input syllable is in unicode scope of valid Hangul.
+/// Note:
+///     this function is valid only for the modern Korean chars.
+///
+pub fn is_hangul(syllable: char) -> bool {
+    let syllable_unicode = syllable as usize;
+
+    if syllable_unicode > HANGUL_END || syllable_unicode < HANGUL_START {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+/// Def:
+///     한글 한 음절을 초성, 중성, 종성 문자로 분리해서 반환
+/// Note:
+///     종성이 없는 경우 종성 테이블의 0번 원소가 반환됨:= '\0'
+pub fn split_syllable(syllable: char) -> (char, char, char) {
+    if is_hangul(syllable) == false {
+        panic!("given syllable is NOT a Hangul.")
+    }
+
+    let (cho_idx, jung_idx, jong_idx) = get_indices_from_syllable(syllable);
+    return (CHO_SUNG[cho_idx], JUNG_SUNG[jung_idx], JONG_SUNG[jong_idx]);
 }
 
 #[cfg(test)]
@@ -190,18 +202,48 @@ mod test_korean_strings {
     }
 
     #[test]
+    fn test_split_syllable() {
+        // '가' => 'ㄱ', 'ㅏ', '\0'
+        let mut test_char = '가';
+        let (initial_consonant, mid_vowel, final_consonant) = split_syllable(test_char);
+        assert_eq!(initial_consonant, 'ㄱ');
+        assert_eq!(mid_vowel, 'ㅏ');
+        assert_eq!(final_consonant, '\0');
+
+        // '헿' => 'ㅎ', 'ㅔ', 'ㅎ'
+        test_char = '헿';
+        let (initial_consonant, mid_vowel, final_consonant) = split_syllable(test_char);
+        assert_eq!(initial_consonant, 'ㅎ');
+        assert_eq!(mid_vowel, 'ㅔ');
+        assert_eq!(final_consonant, 'ㅎ');
+
+        // '왕' => 'ㅇ', 'ㅘ', 'ㅇ'
+        test_char = '왕';
+        let (initial_consonant, mid_vowel, final_consonant) = split_syllable(test_char);
+        assert_eq!(initial_consonant, 'ㅇ');
+        assert_eq!(mid_vowel, 'ㅘ');
+        assert_eq!(final_consonant, 'ㅇ');
+
+        // '뚫' => 'ㄸ', 'ㅜ', 'ㅀ'
+        test_char = '뚫';
+        let (initial_consonant, mid_vowel, final_consonant) = split_syllable(test_char);
+        assert_eq!(initial_consonant, 'ㄸ');
+        assert_eq!(mid_vowel, 'ㅜ');
+        assert_eq!(final_consonant, 'ㅀ');
+    }
+    #[test]
     #[should_panic]
-    fn test_get_indices_from_unicode_goes_panic() {
+    fn test_split_syllable_goes_panic() {
         // digit case
         let mut test_char = '1';
-        get_indices_from_syllable(test_char);
+        split_syllable(test_char);
 
         // english case
         test_char = 'c';
-        get_indices_from_syllable(test_char);
+        split_syllable(test_char);
 
         // special char case
         test_char = '#';
-        get_indices_from_syllable(test_char);
+        split_syllable(test_char);
     }
 }

--- a/src/hangul.rs
+++ b/src/hangul.rs
@@ -1,7 +1,4 @@
 use std::char::from_u32;
-use std::collections::HashMap;
-
-use serde::de::Error;
 
 /// 상수 정의: 유니코드 값 계산을 위해 usize type 사용.
 const HANGUL_START: usize = 44032; // unicode value of '가'

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 mod corpora;
 // use corpora::read_corpus_from_file;
 mod hangul;
+mod trie;
 
 fn main() {
     // let corpus =

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -1,3 +1,44 @@
-/// Split Korean sentences into morpheme, build morpheme trie, search from trie.
-/// 
-/// 
+//! trie structure and its functions
+//!
+//!
+use std::collections::HashMap;
+
+use crate::hangul::{is_hangul, PosTag};
+
+#[derive(Default, Debug)]
+struct TrieNode {
+    character: char,
+    is_end: bool,
+    children: HashMap<char, TrieNode>,
+    tag: Option<PosTag>, // this field has a value if and only if is_end:=True
+}
+
+#[derive(Default, Debug)]
+pub struct Trie {
+    root: TrieNode,
+    total: u32, // the number of nodes in this trie(>= the number of morphemes in dictionary).
+}
+
+impl Trie {
+    pub fn new() -> Self {
+        Trie {
+            root: TrieNode::default(),
+            total: 0,
+        }
+    }
+
+    pub fn insert(&mut self, word: &str, tag: Option<PosTag>) {
+        let mut current_node = &mut self.root;
+
+        for single_char in word.chars() {
+            // iterate over word
+
+            current_node = current_node.children.entry(single_char).or_default();
+        }
+        current_node.is_end = true;
+        if tag.is_none() == false {
+            current_node.tag = tag;
+        }
+    }
+    pub fn search() {}
+}

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -27,22 +27,49 @@ impl Trie {
         }
     }
 
+    fn create_node(&mut self, character: char, is_end: bool) -> TrieNode {
+        let new_node = TrieNode {
+            character: character,
+            is_end: is_end,
+            children: HashMap::default(),
+            tag: None,
+        };
+
+        // self.total += 1;
+        return new_node;
+    }
+
     pub fn insert(&mut self, word: &str, tag: Option<PosTag>) {
-        let mut current_node = &mut self.root;
+        let mut current_node: &mut TrieNode = &mut self.root;
 
         for single_char in word.chars() {
             // iterate over word to deal with each of syllables
             match is_hangul(single_char) {
                 true => {
                     // 한글은 초성, 중성, 종성 나눠서 insert
-                    let (initial_consonant, mid_vowel, final_consonant) =
+                    let (_initial_consonant, _mid_vowel, _final_consonant) =
                         split_syllable(single_char);
-                    current_node = current_node.children.entry(initial_consonant).or_default();
-                    current_node = current_node.children.entry(mid_vowel).or_default();
 
-                    if final_consonant != '\0' {
+                    let initial_consonant = &_initial_consonant;
+                    let mid_vowel = &_mid_vowel;
+                    let final_consonant = &_final_consonant;
+
+                    current_node = current_node
+                        .children
+                        .entry(*initial_consonant)
+                        .or_insert_with(|| self.create_node(*initial_consonant, false));
+
+                    current_node = current_node
+                        .children
+                        .entry(*mid_vowel)
+                        .or_insert_with(|| self.create_node(*mid_vowel, false));
+
+                    if final_consonant.ne(&'\0') {
                         // 종성은 None이 아닌 경우에만 insert
-                        current_node = current_node.children.entry(final_consonant).or_default();
+                        current_node = current_node
+                            .children
+                            .entry(*final_consonant)
+                            .or_insert_with(|| self.create_node(*final_consonant, false));
                     }
                 }
                 false => {
@@ -51,10 +78,46 @@ impl Trie {
                 }
             }
         }
+
         current_node.is_end = true;
         if tag.is_none() == false {
             current_node.tag = tag;
         }
     }
-    pub fn search() {}
+
+    /// this function is for the insert function.
+    /// use "contains" function decripted below to search over trie.
+    fn naive_search(&self, word: &str) -> bool {
+        let mut current_node = &self.root;
+
+        for single_char in word.chars() {
+            match current_node.children.get(&single_char) {
+                Some(node) => current_node = node,
+                None => return false,
+            }
+        }
+
+        current_node.is_end
+    }
+
+    pub fn contains(&self, word: &str) -> bool {
+        // NOT implemented
+        false
+    }
+}
+
+#[cfg(test)]
+mod test_trie {
+    use super::*;
+
+    #[test]
+    fn test_insert_and_search() {
+        let mut trie = Trie::new();
+
+        trie.insert("역삼", Some(PosTag::NNP));
+        assert_eq!(trie.total, 6);
+
+        trie.insert("역", Some(PosTag::NNG));
+        assert_eq!(trie.total, 6);
+    }
 }


### PR DESCRIPTION
## 작업내역
- insert function 구현
- 품사 태그 enum 추가 
- 한글 처리 기능 추가(음절 나누는 함수 인터페이스)
- ~~영어, 숫자 섞여있는 테스트케이스 추가 예정~~ 생각해보니 한글이 아니면 트라이에 넣으면 안될 것 같음
## 테스트케이스 그림
- `역삼, 역도, 역무원, 역도산 ` 순서대로 insert
- 노드 개수를 검사
<img width="352" alt="image" src="https://github.com/NewBornRustacean/MARK/assets/126950833/c0c61b84-309f-4ab2-92dd-d4db8fbb0040">

## 질문
- `insert` 함수 지금 if문 땜질이라 너무 더러운데... 이거 좀 더 우아하게 안될까요~?ㅋㅋㅋ
- `TrieNode` 구조체가 어차피 `Hashmap`을 들고 있으니까 어떤 글자가 입력되었는지는 key로 조회할 수 있도록 만들었습니다. 이게 맞을까요...ㅋㅋㅋㅋㅋ

